### PR TITLE
Fix tests on MacOS/Darwin

### DIFF
--- a/paths_darwin_test.go
+++ b/paths_darwin_test.go
@@ -15,8 +15,8 @@ func TestPaths(t *testing.T) {
 		configFile string
 		logFile    string
 	}{
-		{System, "foobar", "/Library/Application Support/foobar", "/Library/Cache/foobar", "/Library/Preferences/foobar/foobar.conf", "/Library/Logs/foobar/foobar.log"},
-		{User, "foobar", "~/Library/Application Support/foobar", "~/Library/Cache/foobar", "~/Library/Preferences/foobar/foobar.conf", "~/Library/Logs/foobar/foobar.log"},
+		{System, "foobar", "/Library/Application Support/foobar", "/Library/Caches/foobar", "/Library/Preferences/foobar/foobar.conf", "/Library/Logs/foobar/foobar.log"},
+		{User, "foobar", "~/Library/Application Support/foobar", "~/Library/Caches/foobar", "~/Library/Preferences/foobar/foobar.conf", "~/Library/Logs/foobar/foobar.log"},
 	}
 	for _, tt := range tests {
 		s := NewScope(tt.scopeType, "", tt.app)


### PR DESCRIPTION
Tests wrongfully expected /Library/Cache (and ~/Library/Cache) when the
correct (and implemented) paths are /Library/Caches (and
~/Library/Caches).

Apple reference docs: https://developer.apple.com/library/content/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html