### PR TITLE
Fix vendor prefix on macOS & Windows

### DIFF
--- a/paths_darwin.go
+++ b/paths_darwin.go
@@ -15,7 +15,7 @@ var (
 
 // appendPaths appends the app-name and further variadic parts to a path
 func (s *Scope) appendPaths(path string, parts ...string) string {
-	paths := []string{path, s.App}
+	paths := []string{path, s.Vendor, s.App}
 	paths = append(paths, parts...)
 	return filepath.Join(paths...)
 }

--- a/paths_darwin_test.go
+++ b/paths_darwin_test.go
@@ -12,12 +12,43 @@ func TestPaths(t *testing.T) {
 		dataDir    string
 		cacheDir   string
 		configFile string
+		dataFile   string
 		logFile    string
 	}{
-		{NewScope(System, "foobar"), "/Library/Application Support/foobar", "/Library/Caches/foobar", "/Library/Preferences/foobar/foobar.conf", "/Library/Logs/foobar/foobar.log"},
-		{NewScope(User, "foobar"), "~/Library/Application Support/foobar", "~/Library/Caches/foobar", "~/Library/Preferences/foobar/foobar.conf", "~/Library/Logs/foobar/foobar.log"},
-		{NewCustomHomeScope("/tmp", "", "foobar"), "/tmp/Library/Application Support/foobar", "/tmp/Library/Caches/foobar", "/tmp/Library/Preferences/foobar/foobar.conf", "/tmp/Library/Logs/foobar/foobar.log"},
+		{
+			scope:      NewScope(System, "foobar"),
+			dataDir:    "/Library/Application Support/foobar",
+			cacheDir:   "/Library/Caches/foobar",
+			configFile: "/Library/Preferences/foobar/foobar.conf",
+			dataFile:   "/Library/Application Support/foobar/foobar.data",
+			logFile:    "/Library/Logs/foobar/foobar.log",
+		},
+		{
+			scope:      NewVendorScope(System, "barcorp", "foobar"),
+			dataDir:    "/Library/Application Support/barcorp/foobar",
+			cacheDir:   "/Library/Caches/barcorp/foobar",
+			configFile: "/Library/Preferences/barcorp/foobar/foobar.conf",
+			dataFile:   "/Library/Application Support/barcorp/foobar/foobar.data",
+			logFile:    "/Library/Logs/barcorp/foobar/foobar.log",
+		},
+		{
+			scope:      NewScope(User, "foobar"),
+			dataDir:    "~/Library/Application Support/foobar",
+			cacheDir:   "~/Library/Caches/foobar",
+			configFile: "~/Library/Preferences/foobar/foobar.conf",
+			dataFile:   "~/Library/Application Support/foobar/foobar.data",
+			logFile:    "~/Library/Logs/foobar/foobar.log",
+		},
+		{
+			scope:      NewCustomHomeScope("/tmp", "", "foobar"),
+			dataDir:    "/tmp/Library/Application Support/foobar",
+			cacheDir:   "/tmp/Library/Caches/foobar",
+			configFile: "/tmp/Library/Preferences/foobar/foobar.conf",
+			dataFile:   "/tmp/Library/Application Support/foobar/foobar.data",
+			logFile:    "/tmp/Library/Logs/foobar/foobar.log",
+		},
 	}
+
 	for _, tt := range tests {
 		paths, err := tt.scope.DataDirs()
 		if err != nil {
@@ -41,6 +72,14 @@ func TestPaths(t *testing.T) {
 		}
 		if path != expandUser(tt.configFile) {
 			t.Errorf("Expected config path: %s - got: %s", tt.configFile, path)
+		}
+
+		path, err = tt.scope.DataPath(tt.scope.App + ".data")
+		if err != nil {
+			t.Errorf("Error retrieving data path: %s", err)
+		}
+		if path != expandUser(tt.dataFile) {
+			t.Errorf("Expected data path: %s - got: %s", tt.dataFile, path)
 		}
 
 		path, err = tt.scope.LogPath(tt.scope.App + ".log")

--- a/paths_windows.go
+++ b/paths_windows.go
@@ -71,7 +71,7 @@ func (s *Scope) dataDir() (string, error) {
 		return "", ErrRetrievingPath
 	}
 
-	return filepath.Join(path, s.App), nil
+	return filepath.Join(path, s.Vendor, s.App), nil
 }
 
 // dataDirs returns a priority-sorted slice of data dirs.

--- a/paths_windows_test.go
+++ b/paths_windows_test.go
@@ -12,12 +12,43 @@ func TestPaths(t *testing.T) {
 		dataDir    string
 		cacheDir   string
 		configFile string
+		dataFile   string
 		logFile    string
 	}{
-		{NewScope(System, "foobar"), "C:\\ProgramData\\foobar", "C:\\ProgramData\\foobar\\Cache", "C:\\ProgramData\\foobar\\Config\\foobar.conf", "C:\\ProgramData\\foobar\\Logs\\foobar.log"},
-		{NewScope(User, "foobar"), "C:\\Users\\runneradmin\\AppData\\Local\\foobar", "C:\\Users\\runneradmin\\AppData\\Local\\foobar\\Cache", "C:\\Users\\runneradmin\\AppData\\Local\\foobar\\Config\\foobar.conf", "C:\\Users\\runneradmin\\AppData\\Local\\foobar\\Logs\\foobar.log"},
-		{NewCustomHomeScope("C:\\tmp", "", "foobar"), "C:\\tmp", "C:\\tmp\\Cache", "C:\\tmp\\Config\\foobar.conf", "C:\\tmp\\Logs\\foobar.log"},
+		{
+			scope:      NewScope(System, "foobar"),
+			dataDir:    "C:\\ProgramData\\foobar",
+			cacheDir:   "C:\\ProgramData\\foobar\\Cache",
+			configFile: "C:\\ProgramData\\foobar\\Config\\foobar.conf",
+			dataFile:   "C:\\ProgramData\\foobar\\foobar.data",
+			logFile:    "C:\\ProgramData\\foobar\\Logs\\foobar.log",
+		},
+		{
+			scope:      NewVendorScope(System, "barcorp", "foobar"),
+			dataDir:    "C:\\ProgramData\\barcorp\\foobar",
+			cacheDir:   "C:\\ProgramData\\barcorp\\foobar\\Cache",
+			configFile: "C:\\ProgramData\\barcorp\\foobar\\Config\\foobar.conf",
+			dataFile:   "C:\\ProgramData\\barcorp\\foobar\\foobar.data",
+			logFile:    "C:\\ProgramData\\barcorp\\foobar\\Logs\\foobar.log",
+		},
+		{
+			scope:      NewScope(User, "foobar"),
+			dataDir:    "C:\\Users\\runneradmin\\AppData\\Local\\foobar",
+			cacheDir:   "C:\\Users\\runneradmin\\AppData\\Local\\foobar\\Cache",
+			configFile: "C:\\Users\\runneradmin\\AppData\\Local\\foobar\\Config\\foobar.conf",
+			dataFile:   "C:\\Users\\runneradmin\\AppData\\Local\\foobar\\foobar.data",
+			logFile:    "C:\\Users\\runneradmin\\AppData\\Local\\foobar\\Logs\\foobar.log",
+		},
+		{
+			scope:      NewCustomHomeScope("C:\\tmp", "", "foobar"),
+			dataDir:    "C:\\tmp",
+			cacheDir:   "C:\\tmp\\Cache",
+			configFile: "C:\\tmp\\Config\\foobar.conf",
+			dataFile:   "C:\\tmp\\foobar.data",
+			logFile:    "C:\\tmp\\Logs\\foobar.log",
+		},
 	}
+
 	for _, tt := range tests {
 		paths, err := tt.scope.DataDirs()
 		if err != nil {
@@ -41,6 +72,14 @@ func TestPaths(t *testing.T) {
 		}
 		if path != expandUser(tt.configFile) {
 			t.Errorf("Expected config path: %s - got: %s", tt.configFile, path)
+		}
+
+		path, err = tt.scope.DataPath(tt.scope.App + ".data")
+		if err != nil {
+			t.Errorf("Error retrieving data path: %s", err)
+		}
+		if path != expandUser(tt.dataFile) {
+			t.Errorf("Expected data path: %s - got: %s", tt.dataFile, path)
 		}
 
 		path, err = tt.scope.LogPath(tt.scope.App + ".log")


### PR DESCRIPTION
The `Vendor` prefix was previously ignored on macOS & Windows platforms.