### PR TITLE
Use os.UserHomeDir to replace go-homedir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/muesli/go-app-paths
 
 go 1.14
-
-require github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/paths.go
+++ b/paths.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"os"
 	"strings"
-
-	homedir "github.com/mitchellh/go-homedir"
 )
 
 var (
@@ -159,7 +157,7 @@ func (s *Scope) LookupDataFile(filename string) ([]string, error) {
 // expandUser is a helper function that expands the first '~' it finds in the
 // passed path with the home directory of the current user.
 func expandUser(path string) string {
-	if u, err := homedir.Dir(); err == nil {
+	if u, err := os.UserHomeDir(); err == nil {
 		return strings.Replace(path, "~", u, -1)
 	}
 	return path


### PR DESCRIPTION
`os.UserHomeDir` was added in Go 1.12. Use it to avoid a non-stdlib
dependency.